### PR TITLE
Use the fully-qualified collection name for the Ansible builtins

### DIFF
--- a/roles/setup/tasks/configure.yml
+++ b/roles/setup/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure soft/hard file descriptors limits
-  template:
+  ansible.builtin.template:
     src: templates/pam_limits.conf.j2
     dest: /etc/security/limits.d/receptor.conf
     mode: '0600'
@@ -8,7 +8,7 @@
     group: root
 
 - name: Ensure systemd override directory exists
-  file:
+  ansible.builtin.file:
     dest: /etc/systemd/system/receptor.service.d
     state: directory
     owner: root
@@ -16,7 +16,7 @@
     mode: 0755
 
 - name: Override receptor's systemd service runuser
-  template:
+  ansible.builtin.template:
     src: templates/systemd_receptor_override.conf.j2
     dest: /etc/systemd/system/receptor.service.d/override.conf
     mode: '0644'
@@ -25,7 +25,7 @@
 #  notify: Restart Receptor
 
 - name: Configure the receptor socket directory
-  file:
+  ansible.builtin.file:
     path: "{{ receptor_socket_dir }}"
     state: directory
     owner: "{{ receptor_user }}"
@@ -33,7 +33,7 @@
     mode: '0750'
 
 - name: Create tmpfiles.d entry for receptor socket directory
-  template:
+  ansible.builtin.template:
     src: templates/receptor_tmpd.conf.j2
     dest: /etc/tmpfiles.d/receptor.conf
     mode: '0640'

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -15,7 +15,7 @@
   when: receptor_sign or receptor_verify
 
 - name: Deploy receptor config
-  template:
+  ansible.builtin.template:
     src: templates/receptor.conf.j2
     dest: "{{ receptor_config_path }}/receptor.conf"
     mode: '0644'
@@ -25,8 +25,8 @@
   #   - "Receptor Reload"
 
 - name: Start Receptor service
-  systemd:
+  ansible.builtin.systemd:
     name: receptor
     state: started
-    daemon_reload: yes
-    enabled: yes
+    daemon_reload: true
+    enabled: true

--- a/roles/setup/tasks/setup-RedHat.yml
+++ b/roles/setup/tasks/setup-RedHat.yml
@@ -1,10 +1,10 @@
 ---
 - name: Install receptor packages
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ receptor_packages }}"
     state: present
 
 - name: Install dependencies specific to the node type
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ receptor_dependencies | default([]) }}"
     state: present

--- a/roles/setup/tasks/tls.yml
+++ b/roles/setup/tasks/tls.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create Receptor cert directories
-  file:
+  ansible.builtin.file:
     dest: "{{ item }}"
     state: directory
     mode: '0750'
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"
-    recurse: yes
+    recurse: true
   with_items:
     - "{{ receptor_tls_dir }}"
     - "{{ receptor_tls_ca_dir }}"
@@ -16,7 +16,7 @@
   when: custom_tls_certfile is defined or custom_tls_keyfile is defined
 
 - name: Set TLS file permissions
-  file:
+  ansible.builtin.file:
     dest: "{{ item }}"
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"

--- a/roles/setup/tasks/tls_local.yml
+++ b/roles/setup/tasks/tls_local.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure both TLS files are provided
-  assert:
+  ansible.builtin.assert:
     quiet: true
     that:
       - custom_tls_certfile | default('') | length
@@ -9,7 +9,7 @@
       "You must provide both 'custom_tls_certfile' and 'custom_tls_keyfile'."
 
 - name: Ensure CA certfile is provided
-  assert:
+  ansible.builtin.assert:
     quiet: true
     that:
       - custom_ca_certfile | default('') | length
@@ -19,17 +19,19 @@
 - name: Check TLS private key modulus
   delegate_to: localhost
   become: false
-  command: openssl rsa -modulus -noout -in "{{ custom_tls_keyfile }}"
+  ansible.builtin.command: openssl rsa -modulus -noout -in "{{ custom_tls_keyfile }}"
   register: _tls_keyfile_modulus
+  changed_when: false
 
 - name: Check TLS x509 key modulus
   delegate_to: localhost
   become: false
-  command: openssl x509 -modulus -noout -in "{{ custom_tls_certfile }}"
+  ansible.builtin.command: openssl x509 -modulus -noout -in "{{ custom_tls_certfile }}"
   register: _tls_certfile_modulus
+  changed_when: false
 
 - name: Ensure TLS pair matches
-  assert:
+  ansible.builtin.assert:
     quiet: true
     that:
       - _tls_keyfile_modulus.stdout == _tls_certfile_modulus.stdout
@@ -40,12 +42,13 @@
 - name: Ensure x509 certificate was signed by the expected Certificate Authority
   delegate_to: localhost
   become: false
-  command: openssl verify -CAfile "{{ custom_ca_certfile }}" "{{ custom_tls_certfile }}"
+  ansible.builtin.command: openssl verify -CAfile "{{ custom_ca_certfile }}" "{{ custom_tls_certfile }}"
+  changed_when: false
 
 - name: Upload TLS files
-  become: yes
+  become: true
   become_user: "{{ receptor_user }}"
-  copy:
+  ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: "{{ receptor_user }}"

--- a/roles/setup/tasks/variables.yml
+++ b/roles/setup/tasks/variables.yml
@@ -1,10 +1,10 @@
 ---
 - name: Include OS-specific variables (RedHat)
-  include_vars: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
     - ansible_os_family == 'RedHat'
 
 - name: Define receptor_packages
-  set_fact:
+  ansible.builtin.set_fact:
     receptor_packages: "{{ __receptor_packages | list }}"
   when: receptor_packages is not defined

--- a/roles/setup/tasks/worksign_local.yml
+++ b/roles/setup/tasks/worksign_local.yml
@@ -1,6 +1,6 @@
 ---
 - name: Distribute private work signing key
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_worksign_private_keyfile }}"
     dest: "{{ receptor_worksign_private_keyfile }}"
     owner: "{{ receptor_user }}"
@@ -9,7 +9,7 @@
   when: receptor_sign
 
 - name: Distribute public work signing key
-  copy:
+  ansible.builtin.copy:
     src: "{{ custom_worksign_public_keyfile }}"
     dest: "{{ receptor_worksign_public_keyfile }}"
     owner: "{{ receptor_user }}"


### PR DESCRIPTION
As well as preferring 'true' to 'yes', and marking commands that don't change anything as always unchanged.