### PR TITLE
add config file for lint workflow

### DIFF
--- a/.github/workflows/.ansible-lint
+++ b/.github/workflows/.ansible-lint
@@ -1,0 +1,7 @@
+---
+# .ansible-lint
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option will be parsed relative to the CWD of execution.
+exclude_paths:
+  - changelogs/


### PR DESCRIPTION
one more time, this time with meaning

edit: I can add back in the default config if we want and leave it all commented out if preferred. 