### PR TITLE
Add support to Debian/Ubuntu

### DIFF
--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -3,8 +3,8 @@
 - include_tasks: variables.yml
 
 # Setup/install tasks.
-- include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+- include_tasks: "setup-{{ ansible_os_family }}.yml"
+  when: ansible_os_family in ['RedHat', 'Debian']
 
 - name: Create directory for podman runtime config
   ansible.builtin.file:

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -35,6 +35,26 @@
     group: "{{ podman_group }}"
     mode: 0600
 
+- name: Create storage.conf to defer fuse-overlayfs on rootless env
+  ansible.builtin.copy:
+    content:  |
+      [storage]
+      driver = "overlay"
+      [storage.options]
+      mount_program = "/usr/bin/fuse-overlayfs"
+    dest: "~{{ podman_user }}/.config/containers/storage.conf"
+    force: true
+    owner: "{{ podman_user }}"
+    group: "{{ podman_group }}"
+    mode: 0600
+
+- block:
+    - name: Enable linger for {{ podman_user }} user
+      ansible.builtin.command: "loginctl enable-linger {{ podman_user }}"
+  when: 
+    - podman_user != 'root'
+    - ansible_os_family in ['Debian']
+
 - name: Ensure registries.conf.d exists
   ansible.builtin.file:
     path: /etc/containers/registries.conf.d/

--- a/roles/podman/tasks/setup-Debian.yml
+++ b/roles/podman/tasks/setup-Debian.yml
@@ -1,0 +1,5 @@
+---
+- name: Install podman packages
+  ansible.builtin.apt:
+    name: "{{ podman_packages }}"
+    state: present

--- a/roles/podman/tasks/variables.yml
+++ b/roles/podman/tasks/variables.yml
@@ -1,5 +1,5 @@
 ---
-- name: Include OS-specific variables (RedHat)
+- name: Include OS-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
     - ansible_os_family in ['RedHat', 'Debian']

--- a/roles/podman/tasks/variables.yml
+++ b/roles/podman/tasks/variables.yml
@@ -2,7 +2,7 @@
 - name: Include OS-specific variables (RedHat)
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Debian']
 
 - name: Define podman_packages
   ansible.builtin.set_fact:

--- a/roles/podman/vars/Debian.yml
+++ b/roles/podman/vars/Debian.yml
@@ -1,0 +1,3 @@
+__podman_packages:
+  - podman
+  - crun

--- a/roles/setup/defaults/main.yml
+++ b/roles/setup/defaults/main.yml
@@ -35,3 +35,5 @@ receptor_log_level: 'info'
 
 _hostname: "{{ routable_hostname | default(ansible_host) }}"
 receptor_host_identifier: "{{ (_hostname == 'localhost') | ternary('localhost.localdomain', _hostname) }}"
+
+receptor_github_url: https://github.com/ansible/receptor.git

--- a/roles/setup/tasks/configure.yml
+++ b/roles/setup/tasks/configure.yml
@@ -30,6 +30,7 @@
     state: directory
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"
+    recurse: true
     mode: '0750'
 
 - name: Create tmpfiles.d entry for receptor socket directory

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -3,8 +3,8 @@
 - include_tasks: variables.yml
 
 # Setup/install tasks.
-- include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+- include_tasks: "setup-{{ ansible_os_family }}.yml"
+  when: ansible_os_family in ['RedHat', 'Debian']
 
 - include_tasks: configure.yml
 

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -27,6 +27,6 @@
 - name: Start Receptor service
   ansible.builtin.systemd:
     name: receptor
-    state: started
+    state: restarted
     daemon_reload: true
     enabled: true

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -1,0 +1,43 @@
+---
+- name: Install receptor packages
+  ansible.builtin.apt:
+    name: "{{ receptor_packages }}"
+    state: present
+
+- name: Clone ansible-receptor repository
+  ansible.builtin.git:
+    repo: "{{ receptor_github_url }}"
+    dest: /tmp/receptor
+
+- name: Build ansible-receptor
+  community.general.make:
+    chdir: /tmp/receptor
+
+- name: Copy receptor's build to /urs/bin/receptor
+  ansible.builtin.copy:
+    src: /tmp/receptor/receptor
+    dest: /urs/bin/receptor
+    remote_src: true
+
+- name: Add receptor's path to profile
+  ansible.builtin.copy:
+    dest: /etc/profile.d/receptor.sh
+    content: 'PATH=$PATH:/urs/bin/receptor'  
+
+- name: Create receptor's systemd service
+  ansible.builtin.template:
+    src: templates/systemd_receptor.conf.j2
+    dest: /etc/systemd/system/receptor.service
+    mode: '0644'
+    owner: root
+    group: root
+
+- name: Clean receptor folder
+  ansible.builtin.file:
+    state: absent
+    path: /tmp/receptor
+
+- name: Install dependencies specific to the node type
+  ansible.builtin.apt:
+    name: "{{ receptor_dependencies | default([]) }}"
+    state: present

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -4,10 +4,16 @@
     name: "{{ receptor_packages }}"
     state: present
 
+- name: Clean receptor folder
+  ansible.builtin.file:
+    state: absent
+    path: /tmp/receptor
+
 - name: Clone ansible-receptor repository
   ansible.builtin.git:
     repo: "{{ receptor_github_url }}"
     dest: /tmp/receptor
+    force: true
 
 - name: Build ansible-receptor
   community.general.make:

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -19,7 +19,7 @@
   community.general.make:
     chdir: /tmp/receptor
 
-- name: Copy receptor's build to /urs/bin/receptor
+- name: Copy receptor's build to /usr/bin/receptor
   ansible.builtin.copy:
     src: /tmp/receptor/receptor
     dest: /usr/bin/receptor
@@ -33,7 +33,7 @@
 - name: Create receptor's systemd service
   ansible.builtin.template:
     src: templates/systemd_receptor.conf.j2
-    dest: /etc/systemd/system/receptor.service
+    dest: /lib/systemd/system/receptor.service
     mode: '0644'
     owner: root
     group: root

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -22,7 +22,7 @@
 - name: Copy receptor's build to /urs/bin/receptor
   ansible.builtin.copy:
     src: /tmp/receptor/receptor
-    dest: /urs/bin/receptor
+    dest: /usr/bin/receptor
     remote_src: true
 
 - name: Add receptor's path to profile

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -28,7 +28,7 @@
 - name: Add receptor's path to profile
   ansible.builtin.copy:
     dest: /etc/profile.d/receptor.sh
-    content: 'PATH=$PATH:/urs/bin/receptor'  
+    content: 'PATH=$PATH:/usr/bin/receptor'  
 
 - name: Create receptor's systemd service
   ansible.builtin.template:

--- a/roles/setup/tasks/tls_local.yml
+++ b/roles/setup/tasks/tls_local.yml
@@ -46,8 +46,8 @@
   changed_when: false
 
 - name: Upload TLS files
-  become: true
-  become_user: "{{ receptor_user }}"
+  # become: true
+  # become_user: "{{ receptor_user }}"
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"

--- a/roles/setup/tasks/variables.yml
+++ b/roles/setup/tasks/variables.yml
@@ -2,7 +2,7 @@
 - name: Include OS-specific variables (RedHat)
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
-    - ansible_os_family == 'RedHat'
+    - ansible_os_family in ['RedHat', 'Debian']
 
 - name: Define receptor_packages
   ansible.builtin.set_fact:

--- a/roles/setup/tasks/variables.yml
+++ b/roles/setup/tasks/variables.yml
@@ -1,5 +1,5 @@
 ---
-- name: Include OS-specific variables (RedHat)
+- name: Include OS-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
     - ansible_os_family in ['RedHat', 'Debian']

--- a/roles/setup/templates/receptor.conf.j2
+++ b/roles/setup/templates/receptor.conf.j2
@@ -56,9 +56,9 @@
 - {{ peer['protocol'] }}-peer:
     address: {{ peer['address'] | default(peer['host']) }}:{{ peer['port'] }}
     redial: true
-{% if receptor_tls -%}
+    {% if receptor_tls -%}
     tls: tls_client
-{%- endif %}
+    {%- endif %}
 {% endfor %}
 {% endif %}
 

--- a/roles/setup/templates/systemd_receptor.conf.j2
+++ b/roles/setup/templates/systemd_receptor.conf.j2
@@ -2,13 +2,13 @@
 Description=Ansible Receptor for Linux
 After=network.target
 StartLimitIntervalSec=0[Service]
-Type=simple
-Restart=always
-RestartSec=1
 
 [Service]
 ExecStart=/usr/bin/receptor --config /etc/receptor/receptor.conf
 TimeoutStopSec=5
+Type=simple
+Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/setup/templates/systemd_receptor.conf.j2
+++ b/roles/setup/templates/systemd_receptor.conf.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ansible Receptor for Linux
+After=network.target
+StartLimitIntervalSec=0[Service]
+Type=simple
+Restart=always
+RestartSec=1
+
+[Service]
+ExecStart=/usr/bin/receptor --config /etc/receptor/receptor.conf
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target
+Alias=receptor.service

--- a/roles/setup/vars/Debian.yml
+++ b/roles/setup/vars/Debian.yml
@@ -1,0 +1,2 @@
+__receptor_packages:
+  - golang


### PR DESCRIPTION
Hi team,

I modify littlebit the playbook to start the support of ansible-receptor to Debian Systemem.
I tested it on Ubuntu 22.04, Jammy version and apart some "fixing" on AWX Execution install bundle side (that is not under this repo) everything will be installed correctly.

I simply replicate the RedHat installation apart the ansible-receptor install, due to the fact that receptor is not yet ready pubilshed in any Debian pkg.
This is the flow:

- Podman role changes:
  1.  Choice correct variables and setup path based on OS
  2. Install Podman e crun via apt

- Setup role changes:
  1. Choice correct variables and setup path based on OS
  2. Install golang, build ansible-receptor via git clone and `make` , add it into profile (for usage by command line) and create related service

Let me know if I need to change something on this PR.
Thanks