### PR TITLE
fix: correct indentation and line breaks for receptor_peers (#29)

### DIFF
--- a/roles/setup/templates/receptor.conf.j2
+++ b/roles/setup/templates/receptor.conf.j2
@@ -56,9 +56,9 @@
 - {{ peer['protocol'] }}-peer:
     address: {{ peer['address'] | default(peer['host']) }}:{{ peer['port'] }}
     redial: true
-{% if receptor_tls -%}
+{% if receptor_tls %}
     tls: tls_client
-{%- endif %}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
related #29.

Tested by running the same playbook that described in #29 and confirming that generated `receptor.conf` is corrected.

```bash
$ cat /etc/receptor/receptor.conf
---
- node:
...
- tcp-listener:
    port: 27199
    tls: tls_server
- tcp-peer:
    address: exec01.ansible.internal:27199
    redial: true
    tls: tls_client
- tcp-peer:
    address: exec02.ansible.internal:27199
    redial: true
    tls: tls_client
```