### PR TITLE
Add automatic needs_triage issue labeling

### DIFF
--- a/.github/issue_labeler.yml
+++ b/.github/issue_labeler.yml
@@ -1,0 +1,2 @@
+needs_triage:
+  - '.*'

--- a/.github/workflows/triage_new.yml
+++ b/.github/workflows/triage_new.yml
@@ -1,0 +1,21 @@
+name: Triage
+
+"on":
+  issues:
+    types:
+      - opened
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    name: Label
+
+    steps:
+      - name: Label issues
+        uses: github/issue-labeler@v2.4.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          not-before: 2023-01-09T07:00:00Z
+          configuration-path: .github/issue_labeler.yml
+          enable-versioned-regex: 0
+        if: github.event_name == 'issues'


### PR DESCRIPTION
So that issues won't fall through the cracks.