### PR TITLE
breakout config creation into role

### DIFF
--- a/roles/setup/tasks/generate_config.yml
+++ b/roles/setup/tasks/generate_config.yml
@@ -1,0 +1,10 @@
+---
+- name: Deploy receptor config
+  ansible.builtin.template:
+    src: templates/receptor.conf.j2
+    dest: "{{ receptor_config_path }}/receptor.conf"
+    mode: '0644'
+    owner: "{{ receptor_user }}"
+    group: "{{ receptor_group }}"
+  # notify:
+  #   - "Receptor Reload"

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -14,15 +14,7 @@
 - include_tasks: worksign.yml
   when: receptor_sign or receptor_verify
 
-- name: Deploy receptor config
-  ansible.builtin.template:
-    src: templates/receptor.conf.j2
-    dest: "{{ receptor_config_path }}/receptor.conf"
-    mode: '0644'
-    owner: "{{ receptor_user }}"
-    group: "{{ receptor_group }}"
-  # notify:
-  #   - "Receptor Reload"
+- include_tasks: generate_config.yml
 
 - name: Start Receptor service
   ansible.builtin.systemd:


### PR DESCRIPTION
I'd like to be able to just evoke the receptor config generation part for development purposes.