### PR TITLE
Use release install method by default

### DIFF
--- a/roles/setup/defaults/main.yml
+++ b/roles/setup/defaults/main.yml
@@ -36,7 +36,7 @@ receptor_log_level: 'info'
 _hostname: "{{ routable_hostname | default(ansible_host) }}"
 receptor_host_identifier: "{{ (_hostname == 'localhost') | ternary('localhost.localdomain', _hostname) }}"
 
-receptor_install_method: release # options: package, local
+receptor_install_method: release # options: release, package, local
 local_receptor_bin_file: ''
 receptor_install_dir: '/usr/bin'
 

--- a/roles/setup/defaults/main.yml
+++ b/roles/setup/defaults/main.yml
@@ -36,7 +36,7 @@ receptor_log_level: 'info'
 _hostname: "{{ routable_hostname | default(ansible_host) }}"
 receptor_host_identifier: "{{ (_hostname == 'localhost') | ternary('localhost.localdomain', _hostname) }}"
 
-receptor_install_method: package # options: local, release
+receptor_install_method: release # options: package, local
 local_receptor_bin_file: ''
 receptor_install_dir: '/usr/bin'
 


### PR DESCRIPTION
Upstream users likely don't have RHEL subscriptions, so the best option is to install receptor via GitHub Releases.

To install using RHEL dnf, users can pass "receptor_install_method=package" when running installer playbook