### PR TITLE
add receptor_service_name to setup-service.yml

### DIFF
--- a/roles/setup/tasks/setup-service.yml
+++ b/roles/setup/tasks/setup-service.yml
@@ -18,7 +18,7 @@
 - name: Create receptor's systemd service
   ansible.builtin.template:
     src: templates/systemd_receptor.service.j2
-    dest: "{{ systemd_folder }}/receptor.service"
+    dest: "{{ systemd_folder }}/{{ receptor_service_name }}.service"
     mode: '0644'
     owner: root
     group: root

--- a/roles/setup/templates/systemd_receptor.service.j2
+++ b/roles/setup/templates/systemd_receptor.service.j2
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0
 
 [Service]
 ExecStart={{ receptor_install_dir }}/receptor --config {{ receptor_config_dir }}/receptor.conf
-StandardOutput=append:{{ receptor_log_dir }}/receptor.log
+StandardOutput=append:{{ receptor_log_dir }}/{{ receptor_service_name }}.log
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Fix missing `receptor_service_name` on service name.