### PR TITLE
pip break_system_packages method and Ubuntu 24.04 support

### DIFF
--- a/molecule/default/Containerfile_ubuntu.j2
+++ b/molecule/default/Containerfile_ubuntu.j2
@@ -1,0 +1,6 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    init \
+    python3 \
+    && apt-get clean all

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,6 +18,19 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
+  - name: molecule-ubuntu
+    image: ubuntu:24.04
+    dockerfile: Containerfile_ubuntu.j2
+    pre_build_image: false
+    systemd: true
+    privileged: true
+    command: "/usr/lib/systemd/systemd"
+    tmpfs:
+      "/run": "rw,mode=1777"
+      "/tmp": "rw,mode=1777"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
 provisioner:
   name: ansible
   inventory:
@@ -27,6 +40,10 @@ provisioner:
         podman_group: receptor
         ansible_connection: containers.podman.podman
       molecule-debian:
+        ansible_connection: containers.podman.podman
+        podman_user: receptor
+        podman_group: receptor
+      molecule-ubuntu:
         ansible_connection: containers.podman.podman
         podman_user: receptor
         podman_group: receptor

--- a/roles/setup/tasks/python_packages.yml
+++ b/roles/setup/tasks/python_packages.yml
@@ -16,6 +16,8 @@
   when: python_version.stdout is version(minimum_python_version, '<')
 
 - name: Install additional python packages
+  environment:
+    PIP_BREAK_SYSTEM_PACKAGES: 1  # Allow pip to modify externally-managed Python installation
   ansible.builtin.pip:
     name: "{{ additional_python_packages | default([]) }}"
     executable: "{{ pip_executable }}"

--- a/roles/setup/tasks/python_packages.yml
+++ b/roles/setup/tasks/python_packages.yml
@@ -16,8 +16,6 @@
   when: python_version.stdout is version(minimum_python_version, '<')
 
 - name: Install additional python packages
-  environment:
-    PIP_BREAK_SYSTEM_PACKAGES: 1  # Allow pip to modify externally-managed Python installation
   ansible.builtin.pip:
     name: "{{ additional_python_packages | default([]) }}"
     executable: "{{ pip_executable }}"

--- a/roles/setup/tasks/setup-Debian.yml
+++ b/roles/setup/tasks/setup-Debian.yml
@@ -1,4 +1,39 @@
 ---
+- name: Install receptor packages
+  ansible.builtin.package:
+    name: "{{ receptor_packages }}"
+    state: present
+  when:
+    - receptor_install_method == 'package'
+    - receptor_packages
+  notify:
+    - Restart Receptor
+
+# Installing receptor via a package manager already lays down
+# a systemd service file. Instead of replacing it with a new
+# systemd_receptor.service file, we can just use an overrides
+# file to tweak it.
+- name: Setup systemd overrides
+  when: receptor_install_method == 'package'
+  block:
+    - name: Ensure systemd override directory exists
+      ansible.builtin.file:
+        dest: "{{ systemd_folder }}/receptor.service.d"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Override receptor's systemd service runuser
+      ansible.builtin.template:
+        src: templates/systemd_receptor_override.conf.j2
+        dest: "{{ systemd_folder }}/receptor.service.d/override.conf"
+        mode: '0644'
+        owner: root
+        group: root
+      notify:
+        - Restart Receptor
+
 - name: Install dependencies specific to the node type
   ansible.builtin.apt:
     name: "{{ additional_system_packages | default([]) }}"

--- a/roles/setup/tasks/variables.yml
+++ b/roles/setup/tasks/variables.yml
@@ -4,6 +4,7 @@
     file: "{{ item }}"
   with_first_found:
     - files:
+        - '{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml'
         - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml'
         - '{{ ansible_os_family }}.yml'
       paths:

--- a/roles/setup/vars/Ubuntu-24.04.yml
+++ b/roles/setup/vars/Ubuntu-24.04.yml
@@ -1,0 +1,5 @@
+---
+receptor_packages:
+  - receptor
+  - python3-receptorctl
+systemd_folder: "/usr/lib/systemd/system"


### PR DESCRIPTION
Should solve https://github.com/ansible/receptor-collection/issues/63 and https://github.com/ansible/receptor-collection/issues/82

- Allow pip to modify externally-managed Python installs when needed. Can probably be changed to use the [break_system_packages](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html#parameter-break_system_packages) option when when ansible-core 2.17 is no longer considered new.
- Adds support for Ubuntu 24.04. This includes `receptor_install_method=package` since receptor and python3-receptorctl packages exists in the Ubuntu 24.04 repository.