### PR TITLE
Fix for check mode failure when no TLS files exist

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,18 +5,6 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: molecule-centos
-    image: quay.io/centos/centos:stream8
-    pre_build_image: true
-    systemd: true
-    privileged: true
-    command: "/usr/sbin/init"
-    tmpfs:
-      "/run": "rw,mode=1777"
-      "/tmp": "rw,mode=1777"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-
   - name: molecule-debian
     image: debian:11
     dockerfile: Containerfile.j2

--- a/roles/setup/tasks/tls.yml
+++ b/roles/setup/tasks/tls.yml
@@ -15,6 +15,7 @@
   when: custom_tls_certfile is defined or custom_tls_keyfile is defined
 
 - name: Set TLS file permissions
+  ignore_errors: "{{ ansible_check_mode }}"
   ansible.builtin.file:
     dest: "{{ item }}"
     owner: "{{ receptor_user }}"


### PR DESCRIPTION
tie "Set TLS file permissions" task ignore_errors to ansible_check_mode value to allow check mode runs to succeed wen cert/key files do not yet exist on the target machine.