### PR TITLE
Fix the when condition on Install receptor packages task

### DIFF
--- a/roles/setup/tasks/setup-RedHat.yml
+++ b/roles/setup/tasks/setup-RedHat.yml
@@ -5,7 +5,7 @@
     state: present
   when:
     - receptor_install_method == 'package'
-    - receptor_packages
+    - receptor_packages | length > 0
   notify:
     - Restart Receptor
 


### PR DESCRIPTION
# Fix the when condition on receptor setup

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
The when condition on the Install receptor packages task is failing because the `receptor_packages` is a list and not boolean. Following is the failing task.

```
 TASK [ansible.receptor.setup : Install receptor packages] **********************
E           [ERROR]: Task failed: Conditional result was "['receptor', 'receptorctl']" of type 'list', which evaluates to True. Conditionals must have a boolean result.
E           
E           Task failed.
E           Origin: /home/ec2-user/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/setup-RedHat.yml:2:3
E           
E           1 ---
E           2 - name: Install receptor packages
E               ^ column 3
E           
E           <<< caused by >>>
E           
E           Conditional result was "['receptor', 'receptorctl']" of type 'list', which evaluates to True. Conditionals must have a boolean result.
E           Origin: /home/ec2-user/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/setup-RedHat.yml:8:7
E           
E           6   when:
E           7     - receptor_install_method == 'package'
E           8     - receptor_packages
E                   ^ column 7
E           
E           Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
E           
E           fatal: [remote-execution]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result was \"['receptor', 'receptorctl']\" of type 'list', which evaluates to True. Conditionals must have a boolean result."}
E           
```

This changes fixes that and makes it a boolean by making sure length < 0

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1.  Run the nightly pipelines of ocp-b.env-a

### Expected Results
The the pipelines should not fail because of the task failure
