### PR TITLE
Accommodate preflight.yml with ansible-core 2.19

### DIFF
--- a/roles/setup/tasks/preflight.yml
+++ b/roles/setup/tasks/preflight.yml
@@ -1,5 +1,5 @@
 ---
 - name: Check local binary file is set
   ansible.builtin.assert:
-    that: receptor_local_bin_file | length
+    that: receptor_local_bin_file | length > 0
   when: receptor_install_method == 'local'

--- a/roles/setup/tasks/preflight.yml
+++ b/roles/setup/tasks/preflight.yml
@@ -1,5 +1,5 @@
 ---
 - name: Check local binary file is set
   ansible.builtin.assert:
-    that: receptor_local_bin_file | length > 0
+    that: receptor_local_bin_file | default('') | length > 0
   when: receptor_install_method == 'local'


### PR DESCRIPTION
# Accommodate preflight.yml with ansible-core 2.19

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  Accommodate preflight.yml with ansible-core 2.19.
- Why is this change needed?
  Otherwise local receptor binary install with ansible-core 2.19 breaks.
- How does this change address the issue?
  Accommodate preflight.yml with ansible-core 2.19.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
- [ ] CI Update
- [ ] Pre-Commit-Hook update

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
Install the current 2.0.5 ansible.receptor collection.
### Steps to Test
1.  Find out where the current 2.0.5 ansible.receptor collection installed on an EC2 RHEL 9 instance. E.g. /home/ec2-user/.ansible/collections/ansible_collections
2. Apply https://github.com/ansible/receptor-collection/pull/90 , https://github.com/ansible/receptor-collection/pull/91 and code changes in this PR to the respective files (e.g. the respective files under /home/ec2-user/.ansible/collections/ansible_collections/ansible/receptor/).
3. Run the install bundle against ansible-core 2.19 with `receptor_install_method=='local'`

### Expected Results
<!-- Describe what should happen after following the steps -->
Local receptor binary install does not fail with `Conditionals must have a boolean result.`.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->