### PR TITLE
Molecule tests for ansible-core 2.19 compatibility and bool filter

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,15 @@
 - name: Create
   hosts: all
   gather_facts: true
+  vars:
+    # Use non-boolean values to ensure compatibility with Ansible-core >= 2.19
+    receptor_tls: FOO
+    receptor_sign: FOO
+    receptor_verify: FOO
+    receptor_local_only: FOO
+    receptor_listener: FOO
+    receptor_mintls13: FOO
+    receptor_replace_tls: FOO
   tasks:
     - name: Create the receptor user
       ansible.builtin.user:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,20 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Retrieve configuration
+      ansible.builtin.command: cat /etc/receptor/receptor.conf
+      register: config_content
+      changed_when: false
+
+    - name: Assert non-boolean values are handled correctly
+      ansible.builtin.assert:
+        that:
+          - "'work-signing:' not in config_content.stdout"
+          - "'work-verification:' not in config_content.stdout"
+          - "'tls-server:' not in config_content.stdout"
+          - "'tcp-listener:' not in config_content.stdout"
+          - "'local-only' not in config_content.stdout"
+        fail_msg: "False boolean values not handled correctly in configuration"
+        success_msg: "False boolean values handled correctly in configuration"

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,3 @@
 molecule
-# ansible-core 2.19 breaks molecule plugins for now
-ansible-core==2.18.7
+ansible-core
 molecule-plugins[podman]

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -48,11 +48,11 @@
 
 - name: TLS files
   ansible.builtin.include_tasks: tls.yml
-  when: receptor_tls
+  when: receptor_tls | bool
 
 - name: Work signing
   ansible.builtin.include_tasks: worksign.yml
-  when: receptor_sign or receptor_verify
+  when: receptor_sign | bool or receptor_verify | bool
 
 - name: Generate receptor config
   ansible.builtin.include_tasks: generate_config.yml

--- a/roles/setup/tasks/tls_local.yml
+++ b/roles/setup/tasks/tls_local.yml
@@ -52,7 +52,7 @@
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"
     mode: '0640'
-    force: "{{ receptor_replace_tls }}"
+    force: "{{ receptor_replace_tls | bool }}"
   with_items:
     - { src: '{{ custom_tls_certfile }}', dest: '{{ receptor_tls_certfile }}' }
     - { src: '{{ custom_tls_keyfile }}', dest: '{{ receptor_tls_keyfile }}' }

--- a/roles/setup/tasks/worksign_local.yml
+++ b/roles/setup/tasks/worksign_local.yml
@@ -6,7 +6,7 @@
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"
     mode: '0640'
-  when: receptor_sign
+  when: receptor_sign | bool
   notify:
     - Restart Receptor
 
@@ -17,6 +17,6 @@
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"
     mode: '0640'
-  when: receptor_verify
+  when: receptor_verify | bool
   notify:
     - Restart Receptor

--- a/roles/setup/templates/receptor.conf.j2
+++ b/roles/setup/templates/receptor.conf.j2
@@ -2,13 +2,13 @@
 - node:
     id: {{ receptor_host_identifier }}
 
-{% if receptor_sign %}
+{% if receptor_sign | bool %}
 - work-signing:
     privatekey: {{ receptor_worksign_private_keyfile }}
     tokenexpiration: 1m
 {% endif %}
 
-{% if receptor_verify %}
+{% if receptor_verify | bool %}
 - work-verification:
     publickey: {{ receptor_worksign_public_keyfile }}
 {% endif %}
@@ -19,11 +19,11 @@
     service: control
     filename: {{ receptor_socket_dir }}/{{ receptor_control_filename }}
     permissions: 0660
-    {% if receptor_tls -%}
+    {% if receptor_tls | bool -%}
     tls: tls_server
     {%- endif %}
 
-{% if receptor_tls -%}
+{% if receptor_tls | bool -%}
 - tls-server:
     name: tls_server
     cert: {{ receptor_tls_certfile }}
@@ -41,12 +41,12 @@
     mintls13: {{ receptor_mintls13 | bool }}
 {%- endif %}
 
-{% if receptor_local_only %}
+{% if receptor_local_only | bool %}
 - local-only
-{% elif receptor_listener %}
+{% elif receptor_listener | bool %}
 - {{ receptor_protocol }}-listener:
     port: {{ receptor_port }}
-    {% if receptor_tls -%}
+    {% if receptor_tls | bool -%}
     tls: tls_server
     {%- endif %}
 {% endif %}
@@ -60,7 +60,7 @@
     address: {{ peer['address'] }}
 {% endif %}
     redial: true
-{% if receptor_tls %}
+{% if receptor_tls | bool %}
     tls: tls_client
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
# [AAP-49971] Brief Title Describing the Change

## Description

I have expanded molecule tests to include validation for ansible-core 19 truthy values.

If these tests are run without the corresponding changes in ansible-core 19 we get:

```
Conditional result (True) was derived from value of type 'str' at '/home/pablohiro/repos/receptor-collection/molecule/default/converge.yml:7:19'. Conditionals must have a boolean result.
```

With the changes to the collection, we no longer get this error, as `FOO` is correctly converted to boolean `false`.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
- [ ] CI Update
- [ ] Pre-Commit-Hook update

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

N/A

### Steps to Test

1. Run `molecule test`

### Expected Results
Tests should pass.

## Additional Context
N/A

### Screenshots/Logs
Passing locally:
