### PR TITLE
fix: support for Debian 12

### DIFF
--- a/molecule/default/Containerfile.j2
+++ b/molecule/default/Containerfile.j2
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:12
 
 RUN apt-get update && apt-get install -y \
     init \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: podman
 platforms:
   - name: molecule-debian
-    image: debian:11
+    image: debian:12
     dockerfile: Containerfile.j2
     pre_build_image: false
     systemd: true

--- a/roles/setup/tasks/python_packages.yml
+++ b/roles/setup/tasks/python_packages.yml
@@ -19,7 +19,7 @@
   ansible.builtin.pip:
     name: "{{ additional_python_packages | default([]) }}"
     executable: "{{ pip_executable }}"
-    extra_args: "--break-system-packages"
+    extra_args: "{{ '--break-system-packages' if ansible_os_family == 'Debian' else omit }}"
 
 - name: Symlink receptorctl to /usr/bin
   ansible.builtin.file:

--- a/roles/setup/tasks/python_packages.yml
+++ b/roles/setup/tasks/python_packages.yml
@@ -19,6 +19,7 @@
   ansible.builtin.pip:
     name: "{{ additional_python_packages | default([]) }}"
     executable: "{{ pip_executable }}"
+    extra_args: "--break-system-packages"
 
 - name: Symlink receptorctl to /usr/bin
   ansible.builtin.file:


### PR DESCRIPTION
This PR addresses #63 by:

1. Passing --break-system-packages to the pip module when installing additional python packages. This is necessary for Debian 12 (PEP 668) which marks the system environment as externally managed.
2. Updating the molecule tests to use debian:12 instead of debian:11 in Containerfile.j2 and molecule.yml.

Fixes #63