### PR TITLE
Integrate official partner-certification-checker

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,7 @@
 # and not relative to the CWD of execution. CLI arguments passed to the --exclude
 # option will be parsed relative to the CWD of execution.
 exclude_paths:
+  - .github/
   - changelogs/
   - .pre-commit-config.yaml
 

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,9 +1,4 @@
 ---
-# This workflow calls the latest version of the
-# reusable workflow.
-# You can copy this file into your respository if
-# you want to check against pinned versions of
-# Automation Hub tests.
 name: Run collection certification checks
 
 permissions:
@@ -13,38 +8,11 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * *"
 
 concurrency:
   group: cert-ver-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# Files that are not related to the core functionality
-# of your collection can cause Ansible Lint to fail.
-# If this happens, add an .ansible-lint file that includes
-# those files and directories to the root of your
-# repository; for example:
-# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
-# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
-
-# If there are sanity test failures that cannot be fixed and are allowed to ignore
-# https://docs.ansible.com/projects/lint/rules/sanity/, create a sanity ignore file
-# https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location
-# for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
     uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v1.2.0 # zizmor: ignore[unpinned-uses]
-    # If the minimal Ansible Core version your collection supports Ansible
-    # is greater than 2.16.0, specify it below.
-    # You might also have to specify Python version supported by that version,
-    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-    # with:
-    #   ansible-core-version: '2.17.0'
-    #   python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
-    #   collection-root: 'ansible_collections/junipernetworks/junos'
-    #   automation-hub: true
-    # Uncomment the lines below if you have 'automation-hub: true' and need to install collections from Red Hat Ansible Automation Hub.
-    # This requires setting a repository secret called 'AH_TOKEN' which value contains a Red Hat Ansible Automation Hub token.
-    # secrets:
-    #   AH_TOKEN: ${{ secrets.AH_TOKEN }}

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,0 +1,50 @@
+---
+# This workflow calls the latest version of the
+# reusable workflow.
+# You can copy this file into your respository if
+# you want to check against pinned versions of
+# Automation Hub tests.
+name: Run collection certification checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: cert-ver-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+# Files that are not related to the core functionality
+# of your collection can cause Ansible Lint to fail.
+# If this happens, add an .ansible-lint file that includes
+# those files and directories to the root of your
+# repository; for example:
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+
+# If there are sanity test failures that cannot be fixed and are allowed to ignore
+# https://docs.ansible.com/projects/lint/rules/sanity/, create a sanity ignore file
+# https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location
+# for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
+jobs:
+  call:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v1.2.0 # zizmor: ignore[unpinned-uses]
+    # If the minimal Ansible Core version your collection supports Ansible
+    # is greater than 2.16.0, specify it below.
+    # You might also have to specify Python version supported by that version,
+    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+    # with:
+    #   ansible-core-version: '2.17.0'
+    #   python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+    #   collection-root: 'ansible_collections/junipernetworks/junos'
+    #   automation-hub: true
+    # Uncomment the lines below if you have 'automation-hub: true' and need to install collections from Red Hat Ansible Automation Hub.
+    # This requires setting a repository secret called 'AH_TOKEN' which value contains a Red Hat Ansible Automation Hub token.
+    # secrets:
+    #   AH_TOKEN: ${{ secrets.AH_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,43 +48,6 @@ jobs:
           pre-commit run trailing-whitespace --all-files
           pre-commit run markdownlint --all-files
 
-
-  ansible-lint:
-    name: ansible-lint
-    runs-on: ubuntu-latest
-    steps:
-      # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-
-      - name: Install Dependencies
-        run: |
-          pip install -r ci-pip-requirements.txt
-
-      - name: Run ansible-lint
-        run: |
-          ansible-lint -f sarif ./ > ansible-lint-report.txt
-
-      - name: Upload ansible-lint report
-        uses: actions/upload-artifact@v5
-        with:
-          name: ansible-lint-report
-          path: ansible-lint-report.txt
-
-      - name: Create PR number artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "PR_NUMBER: ${{ github.event.number }}" > pr_number.txt
-          cat pr_number.txt
-
-      - name: Upload PR number artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v5
-        with:
-          name: pr_number
-          path: pr_number.txt
-
   antsibull-docs-lint:
     name: antsibull-docs-lint
     runs-on: ubuntu-latest
@@ -101,28 +64,3 @@ jobs:
       - name: Run Anstibull Collection Linting
         run: |
           antsibull-docs lint-collection-docs --plugin-docs .
-
-  galaxy-importer-check:
-    name: galaxy-importer-check
-    runs-on: ubuntu-latest
-    steps:
-      # Important: This sets up your GITHUB_WORKSPACE environment variable
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-
-      - name: Install Dependencies
-        run: |
-          pip install -r ci-pip-requirements.txt
-
-      - name: Build the Collection with ansible-galaxy
-        run: |
-          ansible-galaxy collection build -v --force
-
-      - name: Run Galaxy Importer
-        run: |
-          python -m galaxy_importer.main ansible-receptor-*.tar.gz
-
-      - name: Echo the output of importer_result.json
-        run: |
-          echo importer_result.json


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-70260

## Description
Add the official partner-certification-checker workflow from ansible-collections to automate Red Hat Ansible Automation Hub certification checks.                             
                                                                                                
   Changes:                                                                                     
   - Add .github/workflows/certification.yml from partner-certification-checker                 
   - Update .ansible-lint to exclude .github/ directory                                         
   - Remove duplicate ansible-lint job from ci.yaml (now handled by certification workflow)     
   - Remove duplicate galaxy-importer-check job from ci.yaml (now handled by certification      
   workflow)


