### PR TITLE
feat: bump version 2.0.8 > 2.0.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Ansible.Receptor Release Notes
 
 .. contents:: Topics
 
+v2.0.9
+======
+
+Minor Changes
+-------------
+
+- Integrate official partner-certification-checker
+- pip break_system_packages method and Ubuntu 24.04 support
+- Support for Debian 12
+
 v2.0.8
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -90,3 +90,10 @@ releases:
       bugfixes:
       - Update CHANGELOG.rst
     release_date: '2025-11-19'
+  2.0.9:
+    changes:
+      minor_changes:
+      - Integrate official partner-certification-checker
+      - pip break_system_packages method and Ubuntu 24.04 support
+      - Support for Debian 12
+    release_date: '2026-05-13'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: receptor
-version: 2.0.8
+version: 2.0.9
 readme: README.md
 authors:
   - Ansible


### PR DESCRIPTION
Preparation for 2.0.9 release with latest fixes that support different OS other than Fedora/Red Hat.