### PR TITLE
Update Debian.yml

### DIFF
--- a/roles/setup/vars/Debian.yml
+++ b/roles/setup/vars/Debian.yml
@@ -1,3 +1,2 @@
 ---
 systemd_folder: "/lib/systemd/system"
-receptor_install_method: 'release'   # required beacuse on debian machine no package receptor exists


### PR DESCRIPTION
This unneeded line prevents callers from setting receptor_install_method to `local` on Debian.

# [AAP-XXXXX] Remove unnecessary receptor_install_method override on Debian

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? The vars/Debian.yml which is injected at main.yml:7. 
- Why is this change needed? This variable enforces a value that is already set in defaults/main.yml:40. It prevents users installing on Debian systems from overriding the receptor_install_method variable.
- How does this change address the issue? It removes the unnecessary receptor_install_method variable in vars/Debian.yml 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
- [ ] CI Update
- [ ] Pre-Commit-Hook update

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [X] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test

1. Perform an installation against a Debian system with the 'receptor_install_method' variable set to 'local' in group variables, playbook, etc.
2. Observe as 'release' overrides selected value 

### Expected Results
When installing on Ubuntu with receptor_install_method set to 'local', the local setup should proceed